### PR TITLE
Fix syntax in docs

### DIFF
--- a/docs/react-integration.md
+++ b/docs/react-integration.md
@@ -21,10 +21,10 @@ class TodoList extends React.Component {
 // using `Machine.create` function
 export default connect(TodoList)
   .with('MachineA', 'MachineB')
-  .map((MachineA, MachineB) => {
+  .map((MachineA, MachineB) => ({
     isIdle: MachineA.isIdle,
     todos: MachineB.state.todos
-  });
+  }));
 ```
 
 The result of the mapping function goes as props to our component. Similarly to [Redux's connect `mapStateToProps`](https://github.com/reactjs/react-redux/blob/master/docs/api.md#connectmapstatetoprops-mapdispatchtoprops-mergeprops-options) function. And of course the mapping function is `disconnect`ed when the component is unmounted.


### PR DESCRIPTION
Need additional parenthesis, or else the opening brace `{` in arrow functions is interpreted as the start of the function block rather than an object.