### PR TITLE
Make handlers pure functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,41 @@
+## 6.0.0
+
+Action handlers are pure functions now, i.e. they receive the machine as first argument and do not rely on `this` context.
+
+Custom machine functions are no longer supported.
+
+Example for a handler before 6.x:
+
+```
+'add todo': function (state, todo) {
+  return {
+    name: 'idle',
+    todos: [...state.todos, todo]
+  };
+}
+```
+
+Example for a handler function in 6.x:
+
+```
+'add todo': function ({state}, todo) {
+  return {
+    name: 'idle',
+    todos: [...state.todos, todo]
+  };
+}
+```
+
+Example for an arrow function as handler in 6.x:
+
+```
+'add todo': ({state}, todo) => ({
+    name: 'idle',
+    todos: [...state.todos, todo]
+})
+```
+
+
 ## 5.1.0
 
 Every action now has a dedicated helper to see if it is available in the current machine transition set. For example:
@@ -159,7 +197,7 @@ Adding `onGeneratorStep` to the middleware's hook.
 ## 1.0.0
 
 * Adding `Logger` middleware
-* When adding a middleware the hook `onStateChange` is now called `onStateChanged` 
+* When adding a middleware the hook `onStateChange` is now called `onStateChanged`
 
 ## 0.7.3
 

--- a/docs/action-handler.md
+++ b/docs/action-handler.md
@@ -1,4 +1,4 @@
-# Action handler 
+# Action handler
 
 [Full documentation](./README.md)
 
@@ -29,39 +29,22 @@ Another variant is to use a function that returns a string. Which again results 
 ```js
 Machine.create('app', {
   'idle': {
-    'fetch data': function (state, payload) {
+    'fetch data': function (machine, payload) {
       return 'fetching';
     }
   }
 });
 ```
 
-Notice that the function receives the current state and some payload passed when the action is fired.
+Notice that the function receives the whole state machine and some payload passed when the action is fired.
 
-And of course we may return the actual state object. That's actually a common case because very often we want to keep some data alongside: 
+And of course we may return the actual state object. That's actually a common case because very often we want to keep some data alongside:
 
 ```js
 Machine.create('app', {
   'idle': {
-    'fetch data': function (state, payload) {
+    'fetch data': function (machine, payload) {
       return { name: 'fetching', answer: 42 };
-    }
-  }
-});
-```
-
-The context of the action handler function (or generator) is the machine itself. This means that `this` inside the function points to the created machine and we may call its methods. For example:
-
-```js
-Machine.create('app', {
-  'idle': {
-    'fetch data': function (state, payload) {
-      if (this.isIdle()) {
-        this.request('/api/todos');
-      }
-    },
-    'request': function (state, endpoint) {
-      console.log(endpoint); // endpoint = /api/todos
     }
   }
 });
@@ -74,7 +57,7 @@ We may also use a generator if we have more complex operations or/and async task
 ```js
 Machine.create('app', {
   'idle': {
-    'fetch data': function * (state, payload) {
+    'fetch data': function * (machine, payload) {
       yield 'fetching'; // transition to a `fetching` state
       yield { name: 'fetching' } // the same but using a state object
     }

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -50,10 +50,10 @@ const machine = Machine.create('todo-app', {
   state: { name: 'idle', todos: [] },
   transitions: {
     'idle': {
-      'add todo': function (state, todo) {
+      'add todo': function (machine, todo) {
         return {
           name: 'idle',
-          todos: [...state.todos, todo]
+          todos: [...machine.state.todos, todo]
         };
       }
     }

--- a/examples/todo-app/src/machines/ToDos.js
+++ b/examples/todo-app/src/machines/ToDos.js
@@ -7,7 +7,7 @@ function * saveTodos (todos) {
     return { name: 'idle', todos: [ ...todos ] };
   } catch(error) {
     throw new Error(error);
-  } 
+  }
 }
 
 export default {
@@ -39,8 +39,8 @@ export default {
       }
     },
     fetching: {
-      'todos loaded': (state, todos) => ({ name: 'idle', todos }),
-      'error': (state, error) => ({ name: 'error', error })
+      'todos loaded': (machine, todos) => ({ name: 'idle', todos }),
+      'error': (machine, error) => ({ name: 'error', error })
     },
     error: {
       'fetch todos': function * () {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stent",
-  "version": "5.1.1",
+  "version": "6.0.0",
   "description": "Stent is combining the ideas of redux with the concept of state machines",
   "main": "lib",
   "scripts": {

--- a/src/__tests__/createMachine.spec.js
+++ b/src/__tests__/createMachine.spec.js
@@ -55,9 +55,27 @@ describe('Given the createMachine factory', function () {
         state: { name: 'idle' },
         transitions: {
           'idle': {
-            'run baby run': function (state, a, b) {
+            'run baby run': function (machine, a, b) {
               return { name: 'running', data: [a, b] };
             }
+          },
+          'running': { stop: 'idle' }
+        }
+      });
+
+      machine.runBabyRun('a', 'b');
+      expect(machine.state.name).to.equal('running');
+      expect(machine.state.data).to.deep.equal(['a', 'b']);
+    });
+    it('it should handle the action implemented as arrow function', function () {
+      const machine = createMachine({
+        state: { name: 'idle' },
+        transitions: {
+          'idle': {
+            'run baby run': (machine, a, b) => ({
+               name: 'running',
+               data: [a, b]
+            })
           },
           'running': { stop: 'idle' }
         }

--- a/src/__tests__/createMachine.spec.js
+++ b/src/__tests__/createMachine.spec.js
@@ -68,27 +68,4 @@ describe('Given the createMachine factory', function () {
       expect(machine.state.data).to.deep.equal(['a', 'b']);
     });
   });
-
-  describe('when we create the machine with custom methods', function () {
-    it('they should be available and should be called with the machine as a context', function () {
-      const machine = createMachine({
-        state: { name: 'idle', bar: 'zar' },
-        transitions: {
-          'idle': {
-            'run baby run': function (state, a, b) {
-              return this.foo(a, b);
-            }
-          },
-          'running_abzar': { stop: 'idle' }
-        },
-        foo(a, b) {
-          return 'running_' + a + b + this.state.bar;
-        }
-      });
-
-      machine.runBabyRun('a', 'b');
-      expect(machine.state.name).to.equal('running_abzar');
-    });
-  });
-
 });

--- a/src/createMachine.js
+++ b/src/createMachine.js
@@ -24,18 +24,12 @@ export default function createMachine(name, config) {
 
   validateConfig(config);
 
-  const { state: initialState, transitions, ...customMethods } = config;
+  const { state: initialState, transitions} = config;
   const dispatch = (action, ...payload) => handleAction(machine, action, ...payload);
   const dispatchLatest = (action, ...payload) => handleActionLatest(machine, action, ...payload);
 
   machine.state = initialState;
   machine.transitions = transitions;
-  
-  if (customMethods) {
-    for(let key in customMethods) {
-      machine[key] = customMethods[key];
-    }
-  }
 
   registerMethods(
     machine,
@@ -43,6 +37,6 @@ export default function createMachine(name, config) {
     dispatch,
     dispatchLatest
   );
-  
+
   return machine;
 }

--- a/src/helpers/__tests__/handleAction.spec.js
+++ b/src/helpers/__tests__/handleAction.spec.js
@@ -115,7 +115,7 @@ describe('Given the handleAction function', function () {
   });
 
   describe('when the handler is a function', function () {
-    it('should call the handler with the current state and the given payload', function () {
+    it('should call the handler with the machine and the given payload', function () {
       const handler = sinon.spy();
       const payload = ['foo', 'bar', 'baz'];
       const machine = {
@@ -128,7 +128,7 @@ describe('Given the handleAction function', function () {
 
       handleAction(machine, 'run', ...payload);
       expect(handler).to.be.calledOnce.and.to.be.calledWith(
-        { name: 'idle'}, 'foo', 'bar', 'baz'
+        machine, 'foo', 'bar', 'baz'
       );
     });
     it('should update the state', function () {
@@ -156,21 +156,6 @@ describe('Given the handleAction function', function () {
 
       handleAction(machine, 'run');
       expect(machine.state).to.deep.equal({ name: 'bar' });
-    });
-    it('should run the handler with the machine as a context', function () {
-      const handler = function () {
-        expect(this.state).to.deep.equal({ name: 'idle', data: 42 });
-        return 'foo';
-      }
-      const machine = {
-        state: { name: 'idle', data: 42 },
-        transitions: {
-          idle: { run: handler },
-          foo: { a: 'b' }
-        }
-      };
-
-      handleAction(machine, 'run');
     });
   });
 

--- a/src/helpers/handleAction.js
+++ b/src/helpers/handleAction.js
@@ -19,18 +19,18 @@ export default function handleAction(machine, action, ...payload) {
   if (typeof handler === 'undefined') return false;
 
   handleMiddleware(MIDDLEWARE_PROCESS_ACTION, machine, action, ...payload);
-  
+
   // string as a handler
   if (typeof handler === 'string') {
     updateState(machine, { ...state, name: transitions[state.name][action] });
-    
+
   // object as a handler
   } else if (typeof handler === 'object') {
     updateState(machine, handler);
 
   // function as a handler
   } else if (typeof handler === 'function') {
-    var response = transitions[state.name][action].apply(machine, [ machine.state, ...payload ]);
+    const response = transitions[state.name][action](machine, ...payload);
 
     // generator
     if (response && typeof response.next === 'function') {
@@ -44,7 +44,7 @@ export default function handleAction(machine, action, ...payload) {
       updateState(machine, response);
     }
 
-    
+
   // wrong type of handler
   } else {
     throw new Error(ERROR_NOT_SUPPORTED_HANDLER_TYPE);

--- a/src/react/__tests__/connect.spec.js
+++ b/src/react/__tests__/connect.spec.js
@@ -100,8 +100,8 @@ describe('Given the connect React helper', function () {
           state: { name: 'idle', counter: 0 },
           transitions: {
             idle: {
-              run: function ({ counter }) {
-                return { name: 'idle', counter: counter + 1 };
+              run: function ({ state }) {
+                return { name: 'idle', counter: state.counter + 1 };
               }
             }
           }


### PR DESCRIPTION
As discussed in #23 this PR changes how function action handlers are called and now the first argument is always the whole machine:

Example for a handler function in 6.x:

```
'add todo': function ({state}, todo) {
  return {
    name: 'idle',
    todos: [...state.todos, todo]
  };
}
```

Example for an arrow function as handler in 6.x:

```
'add todo': ({state}, todo) => ({
    name: 'idle',
    todos: [...state.todos, todo]
})
```

I've tried to update all examples and tests to match this change, let me know if I've missed anything.