### PR TITLE
Add test for async action handler scheduling

### DIFF
--- a/src/__tests__/action-handler-scheduling.spec.js
+++ b/src/__tests__/action-handler-scheduling.spec.js
@@ -1,0 +1,88 @@
+import { Machine } from "../";
+import { connect, call } from "../helpers";
+
+const sleep = function sleep(ms = 100) {
+  return new Promise(function(resolve) {
+    setTimeout(resolve, ms);
+  });
+};
+
+const noop = function noop(machine) {
+  return { ...machine.state };
+};
+
+describe("Stent machine", function() {
+  beforeEach(() => {
+    Machine.flush();
+  });
+
+  describe("when an async action handler is running", function() {
+    this.timeout(5000);
+
+    it("should accept state changes from other action handlers", function() {
+      return new Promise(function(resolve, reject) {
+        const machine = Machine.create("app", {
+          state: { name: "A" },
+          transitions: {
+            A: {
+              init: function* init(machine) {
+                yield call(sleep, 100);
+
+                yield { ...machine.state, name: "B" };
+
+                yield call(sleep, 100);
+
+                return yield { ...machine.state, name: "C" };
+              },
+              goToD: function* goToD(machine) {
+                yield call(sleep, 100);
+
+                return yield { ...machine.state, name: "D" };
+              },
+              syncGoToE: function syncGoToE(machine) {
+                return { ...machine.state, name: "E" };
+              }
+            },
+            B: {
+              noop
+            },
+            C: {
+              noop
+            },
+            D: {
+              noop
+            },
+            E: {
+              noop
+            }
+          }
+        });
+
+        let actual = [];
+
+        const expected = ["A", "E", "B", "D", "C"];
+
+        connect()
+          .with(machine.name)
+          .map(function(m) {
+            const stateName = m.state.name;
+
+            actual.push(stateName);
+
+            if (stateName === "C") {
+              try {
+                expect(actual).to.deep.equal(expected);
+                resolve();
+              } catch (err) {
+                reject(err);
+              }
+            }
+          });
+
+        machine.init();
+        machine.goToD();
+        machine.syncGoToE();
+      });
+    });
+  });
+});


### PR DESCRIPTION
I have created a passing test that illustrates how the state transitions are scheduled if the user triggers multiple actions simultaneously. Would you consider adding it to the test suite?

With this test, I wanted to verify how triggering another allowed action while an async action handler is running will affect state changes, e.g.,

- Will Stent wait for the first action handler to complete and then run the remaining action handler?
- Or will it intermix the state transitions, and if yes, in what order?

*Of course, the most optimal way to build a long-running action handler is to immediately transition to another state that forbids disruptive actions and then carry on with async tasks.*