### PR TITLE
Catch errors thrown by the function result of the call helper

### DIFF
--- a/src/helpers/__tests__/handleGenerator.spec.js
+++ b/src/helpers/__tests__/handleGenerator.spec.js
@@ -30,4 +30,22 @@ describe('Given the handleGenerator helper', function () {
       });
     });
   });
+  
+  it("should catch errors in the function result of the call helper", function () {
+    const mistake = () => {
+      throw new Error("oops");
+    };
+
+    const generator = function* () {
+      try {
+        yield call(mistake);
+      } catch (err) {
+        return yield call(() => err.message);
+      }
+    };
+
+    handleGenerator({}, generator(), (result) =>
+      expect(result).to.be.equal("oops")
+    );
+  });
 });

--- a/src/helpers/handleGenerator.js
+++ b/src/helpers/handleGenerator.js
@@ -28,39 +28,43 @@ export default function handleGenerator(machine, generator, done, resultOfPrevio
           return iterate(generatorThrow(generator, new Error(error)));
         }
 
-        const funcResult = func(...args);
+        try {
+          const funcResult = func(...args);
 
-        if (!funcResult) {
-          handleMiddleware(MIDDLEWARE_GENERATOR_RESUMED, machine);
-          iterate(generatorNext(generator));
-          return;
-        }
-        
-        // promise
-        if (typeof funcResult.then !== 'undefined') {
-          funcResult.then(
-            result => {
-              handleMiddleware(MIDDLEWARE_GENERATOR_RESUMED, machine, result);
-              return iterate(generatorNext(generator, result));
-            },
-            error => {
-              handleMiddleware(MIDDLEWARE_GENERATOR_RESUMED, machine, error);
+          if (!funcResult) {
+            handleMiddleware(MIDDLEWARE_GENERATOR_RESUMED, machine);
+            iterate(generatorNext(generator));
+            return;
+          }
+          
+          // promise
+          if (typeof funcResult.then !== 'undefined') {
+            funcResult.then(
+              result => {
+                handleMiddleware(MIDDLEWARE_GENERATOR_RESUMED, machine, result);
+                return iterate(generatorNext(generator, result));
+              },
+              error => {
+                handleMiddleware(MIDDLEWARE_GENERATOR_RESUMED, machine, error);
+                return iterate(generatorThrow(generator, error));
+              }
+            );
+          // generator
+          } else if (typeof funcResult.next === 'function') {
+            try {
+              cancelInsideGenerator = handleGenerator(machine, funcResult, generatorResult => {
+                handleMiddleware(MIDDLEWARE_GENERATOR_RESUMED, machine, generatorResult);
+                iterate(generatorNext(generator, generatorResult));
+              });
+            } catch (error) {
               return iterate(generatorThrow(generator, error));
             }
-          );
-        // generator
-        } else if (typeof funcResult.next === 'function') {
-          try {
-            cancelInsideGenerator = handleGenerator(machine, funcResult, generatorResult => {
-              handleMiddleware(MIDDLEWARE_GENERATOR_RESUMED, machine, generatorResult);
-              iterate(generatorNext(generator, generatorResult));
-            });
-          } catch (error) {
-            return iterate(generatorThrow(generator, error));
+          } else {
+            handleMiddleware(MIDDLEWARE_GENERATOR_RESUMED, machine, funcResult);
+            iterate(generatorNext(generator, funcResult));
           }
-        } else {
-          handleMiddleware(MIDDLEWARE_GENERATOR_RESUMED, machine, funcResult);
-          iterate(generatorNext(generator, funcResult));
+        } catch (error) {
+          return iterate(generatorThrow(generator, error));
         }
 
       // a return statement of the normal function


### PR DESCRIPTION
In the `handleGenerator` function, the [function result](https://github.com/krasimir/stent/blob/13e0fc53e955c699deb9aa721c762e2e843d0cb1/src/helpers/handleGenerator.js#L31) of the `call` helper is evaluated without catching the errors it may throw. Therefore, if it throws an error, the `handleGenerator`'s function execution will stop.

Issue #47 